### PR TITLE
fix: name seldon to seldon-core

### DIFF
--- a/distribution/argocd-applications/seldon.yaml
+++ b/distribution/argocd-applications/seldon.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: seldon
+  name: seldon-core
   namespace: argocd
 spec:
   project: default

--- a/template/argocd-applications/seldon.yaml
+++ b/template/argocd-applications/seldon.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: seldon
+  name: seldon-core
   namespace: argocd
 spec:
   project: default


### PR DESCRIPTION
One little fix that was not included in the https://github.com/StatCan/aaw-argoflow-azure/commit/cf0bc051dcba7e30a39c9cc5ad89307b3a91e598 commit.

closes https://github.com/StatCan/aaw-argoflow-azure/issues/5